### PR TITLE
Remove debug function as it is't available as long as the shop doesn't run in debug mode

### DIFF
--- a/tpl/widget/header/loginbox.html.twig
+++ b/tpl/widget/header/loginbox.html.twig
@@ -1,5 +1,5 @@
 {% set bIsError = 0 %}
-{{ dump(Errors.loginBoxErrors) }}
+
 {% capture name = "loginErrors" %}
     {% for key, oEr in Errors.loginBoxErrors %}
         <p id="errorBadLogin" class="alert alert-danger">{{ oEr.getOxMessage() }}</p>


### PR DESCRIPTION
In the last commit the debug function was introduced but it causes an exception in the frontpage as the shop runs by default in a non debug mode.