### PR TITLE
fix setup error message and and general error message rendering

### DIFF
--- a/tpl/message/err_setup.html.twig
+++ b/tpl/message/err_setup.html.twig
@@ -6,6 +6,6 @@
             <div>{{ translate({ ident: "MESSAGE_PLEASE_DELETE_FOLLOWING_DIRECTORY", suffix: "COLON" }) }} {{ oViewConf.getBaseDir() }}/setup!</div>
         </div>
     {% endcapture %}
-    {% include "message/error.html.twig" with {statusMessage: ""|implode(_error_content)} %}
+    {% include "message/error.html.twig" with {statusMessage: _error_content|join} %}
 {% endcapture %}
 {% include "layout/base.html.twig" %}

--- a/tpl/message/error.html.twig
+++ b/tpl/message/error.html.twig
@@ -1,1 +1,1 @@
-<p class="alert alert-danger">{{ statusMessage }}</p>
+<p class="alert alert-danger">{{ statusMessage|raw }}</p>


### PR DESCRIPTION
"implode" is not a valid Twig filter.
The statusMessage variable needs to be rendered raw because it can contain HTML.
