### PR TITLE
syntactical errors

### DIFF
--- a/tpl/email/html/order_cust.html.twig
+++ b/tpl/email/html/order_cust.html.twig
@@ -132,7 +132,7 @@
 
     {% for basketindex, basketitem in basket.getContents() %}
         {% block email_html_order_cust_basketitem %}
-            {% set basketproduct = basketitemlist.basketindex %}
+            {% set basketproduct = basketitemlist[basketindex] %}
 
             <tr valign="top">
                 {% if oViewConf.getViewThemeParam('blEmailsShowProductPictures') %}

--- a/tpl/email/html/order_owner.html.twig
+++ b/tpl/email/html/order_owner.html.twig
@@ -124,7 +124,7 @@
     {% set basketitemlist = basket.getBasketArticles() %}
     {% for basketindex, basketitem in basket.getContents() %}
         {% block email_html_order_owner_basketitem %}
-            {% set basketproduct = basketitemlist.basketindex %}
+            {% set basketproduct = basketitemlist[basketindex] %}
             <tr valign="top">
                 {% if oViewConf.getViewThemeParam('blEmailsShowProductPictures') %}
                     <td>

--- a/tpl/email/plain/order_cust.html.twig
+++ b/tpl/email/plain/order_cust.html.twig
@@ -30,7 +30,7 @@
 {% set basketitemlist = basket.getBasketArticles() %}
 {% for basketindex, basketitem in basket.getContents() %}
 {% block email_plain_order_cust_basketitem %}
-{% set basketproduct = basketitemlist.basketindex %}
+{% set basketproduct = basketitemlist[basketindex] %}
 {{ basketproduct.oxarticles__oxtitle.value|striptags }}{% if basketproduct.oxarticles__oxvarselect.value %}, {{ basketproduct.oxarticles__oxvarselect.value }}{% endif %}
 {% if basketitem.getChosenSelList() %}{% for oList in basketitem.getChosenSelList() %}
 

--- a/tpl/email/plain/order_owner.html.twig
+++ b/tpl/email/plain/order_owner.html.twig
@@ -28,7 +28,7 @@
 {% set basketitemlist = basket.getBasketArticles() %}
 {% for basketindex, basketitem in basket.getContents() %}
 {% block email_plain_order_ownerbasketitem %}
-{% set basketproduct = basketitemlist.basketindex %}
+{% set basketproduct = basketitemlist[basketindex] %}
 {{ basketproduct.oxarticles__oxtitle.value|striptags }}{% if basketproduct.oxarticles__oxvarselect.value %}, {{ basketproduct.oxarticles__oxvarselect.value }}{% endif %}
 {% if basketitem.getChosenSelList() %}{% for oList in basketitem.getChosenSelList() %}{{ oList.name }} {{ oList.value }}{% endfor %}{% endif %}
 {% if basketitem.getPersParams() %}{% for sVar, aParam in basketitem.getPersParams() %}{{ sVar }} : {{ aParam }}{% endfor %}{% endif %}

--- a/tpl/page/account/order.html.twig
+++ b/tpl/page/account/order.html.twig
@@ -76,7 +76,7 @@
                                                 {% endif %}
                                             {% endfor %}
                                             {# Commented due to Trusted Shops precertification. Enable if needed #}
-                                            [{*
+                                            {#
                                             {% hasrights { "ident": "TOBASKET",} %}
                                             {% if oArticle.isBuyable() %}
                                               {% if oArticle.oxarticles__oxid.value %}
@@ -84,7 +84,7 @@
                                               {% endif %}
                                             {% endif %}
                                             {% endhasrights %}
-                                            *}]
+                                            #}
                                         </li>
                                     {% endfor %}
                                 </ol>


### PR DESCRIPTION
The templates for the emails contain syntactical errors that prevent images and item numbers from being displayed.